### PR TITLE
Disable /admin page if vaultwarden_config_admin_token is no longer set

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -51,11 +51,11 @@
     path: "{{ vaultwarden_data_dir_path }}/config.json"
   register: config
 
-- name: Ensure Vaultwarden /admin page is set correctly
+- name: Clear potentially-existing previous admin_token config value if  vaultwarden_config_admin_token is unset
   ansible.builtin.lineinfile:
     name: "{{ vaultwarden_data_dir_path }}/config.json"
     line: "admin_token"
     state: absent
   when:
     - config.stat.exists
-    - vaultwarden_config_admin_token is undefined
+    - vaultwarden_config_admin_token == ''

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -45,3 +45,17 @@
     src: "{{ role_path }}/templates/vaultwarden.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ vaultwarden_identifier }}.service"
     mode: 0640
+
+- name: Check if Vaultwarden config exists
+  ansible.builtin.stat:
+    path: "{{ vaultwarden_data_dir_path }}/config.json"
+  register: config
+
+- name: Ensure Vaultwarden /admin page is set correctly
+  ansible.builtin.lineinfile:
+    name: "{{ vaultwarden_data_dir_path }}/config.json"
+    line: "admin_token"
+    state: absent
+  when:
+    - config.stat.exists
+    - vaultwarden_config_admin_token is undefined


### PR DESCRIPTION
In response to [#179](https://github.com/mother-of-all-self-hosting/mash-playbook/issues/179), here is a pull request.

I did minor regression testing, and works correctly on my debian box.

No value in vars.yml -> value in vars.yml -> Remove value in vars.yml

Update: That is my commit, I forgot to add my new sign key to Github 😅