### PR TITLE
Don't include `tls.certResolver` label if entrypoint is `web`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -257,6 +257,7 @@ vaultwarden_container_labels_traefik_path_prefix: "{{ vaultwarden_path_prefix }}
 vaultwarden_container_labels_traefik_rule_ui: "Host(`{{ vaultwarden_container_labels_traefik_hostname }}`){% if vaultwarden_container_labels_traefik_path_prefix != '/' %} && PathPrefix(`{{ vaultwarden_container_labels_traefik_path_prefix | quote }}`){% endif %}"
 vaultwarden_container_labels_traefik_priority: 0
 vaultwarden_container_labels_traefik_entrypoints: web-secure
+vaultwarden_container_labels_traefik_tls: "{{ vaultwarden_container_labels_traefik_entrypoints != 'web' }}"
 vaultwarden_container_labels_traefik_tls_certResolver: default  # noqa var-naming
 
 # Controls whether a compression middleware will be injected into the middlewares list.

--- a/templates/labels.j2
+++ b/templates/labels.j2
@@ -33,7 +33,11 @@ traefik.http.routers.{{ vaultwarden_identifier }}.priority={{ vaultwarden_contai
 {% endif %}
 
 traefik.http.routers.{{ vaultwarden_identifier }}.service={{ vaultwarden_identifier }}
+
+{% if vaultwarden_container_labels_traefik_tls %}
 traefik.http.routers.{{ vaultwarden_identifier }}.tls.certResolver={{ vaultwarden_container_labels_traefik_tls_certResolver }}
+{% endif %}
+
 traefik.http.routers.{{ vaultwarden_identifier }}.entrypoints={{ vaultwarden_container_labels_traefik_entrypoints }}
 traefik.http.services.{{ vaultwarden_identifier }}.loadbalancer.server.port={{ vaultwarden_config_rocket_port }}
 {% endif %}


### PR DESCRIPTION
Closes https://github.com/mother-of-all-self-hosting/ansible-role-vaultwarden/issues/3

Don't include `tls.certResolver` label if entrypoint is `web`